### PR TITLE
Quick fix which get the pwd either in object or _source

### DIFF
--- a/lib/passport/strategy.js
+++ b/lib/passport/strategy.js
@@ -11,7 +11,7 @@ module.exports = function(context) {
     repositories.user.load(username)
       .then(userObject => {
         if (userObject !== null) {
-          context.passwordManager.checkPassword(password, userObject.password)
+          context.passwordManager.checkPassword(password, userObject.password || userObject._source.password)
             .then(result => {
               if (result === false) {
                 deferred.reject(new context.ForbiddenError('Bad Credentials'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-auth-passport-local",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Kuzzle plugin to log-in users",
   "main": "./lib/index.js",
   "repository": {


### PR DESCRIPTION
This PR is a temporary fix to get the password of a userObject either in the object itself or in _source while waiting for a fix in the userRepository of Kuzzle (in progress).