### PR TITLE
KUZ-613: repositories in plugincontext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/kuzzleio/kuzzle-plugin-auth-passport-local.svg?branch=master)](https://travis-ci.org/kuzzleio/kuzzle-plugin-auth-passport-local)
 
-![logo](https://raw.githubusercontent.com/kuzzleio/kuzzle/master/docs/images/logo.png)
+<p align=center> ![logo](http://kuzzle.io/guide/images/kuzzle.svg)
 
 # Kuzzle compatibility
 

--- a/lib/config/hooks.js
+++ b/lib/config/hooks.js
@@ -1,3 +1,0 @@
-module.exports = {
-  'auth:loadStrategies': 'loadStrategy'
-};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,15 +1,17 @@
 var
   _ = require('lodash'),
-  hooks = require('./config/hooks'),
   pipes = require('./config/pipes'),
   PasswordManager = require('./passwordManager'),
   Strategy = require('./passport/strategy');
 
 module.exports = function () {
-  this.isDummy = false;
+  this.isDummy = true;
   this.context = {};
+  this.pipes = pipes;
 
   this.init = function (config, context, isDummy) {
+    var strategy;
+
     if (!config) {
       console.error(new Error('plugin-auth-passport-local: A configuration is required for plugin kuzzle-plugin-auth-passport-local'));
       return false;
@@ -32,15 +34,10 @@ module.exports = function () {
 
     this.context.passwordManager = new PasswordManager(config);
 
+    strategy = new Strategy(this.context);
+    strategy.load();
+
     return this;
-  };
-
-  this.pipes = pipes;
-  this.hooks = hooks;
-
-  this.loadStrategy = function (passport) {
-    var strategy = new Strategy(this.context);
-    strategy.load(passport);
   };
 
   this.cleanUserCredentials = function(user, callback) {

--- a/lib/passport/strategy.js
+++ b/lib/passport/strategy.js
@@ -2,27 +2,29 @@ var
   LocalStrategy = require('passport-local').Strategy;
 
 module.exports = function(context) {
+  this.context = context;
+
   this.verify = function(username, password, done) {
-    context.accessors.users.load(username)
+    this.context.accessors.users.load(username)
       .then(userObject => {
         if (userObject !== null) {
-          context.passwordManager.checkPassword(password, userObject.password || userObject._source.password)
+          this.context.passwordManager.checkPassword(password, userObject.password || userObject._source.password)
             .then(result => {
               if (result === false) {
-                return done(new context.errors.ForbiddenError('Bad Credentials'));
+                return done(new this.context.errors.ForbiddenError('Login failed'));
               }
 
               done(null, userObject);
             });
         }
         else {
-          done(new context.errors.ForbiddenError('Bad Credentials'));
+          done(new this.context.errors.ForbiddenError('Login failed'));
         }
       })
       .catch(err => done(err));
   };
 
-  this.load = function(passport) {
-    passport.use(new LocalStrategy(this.verify));
+  this.load = function() {
+    this.context.accessors.passport.use(new LocalStrategy(this.verify));
   };
 };

--- a/lib/passport/strategy.js
+++ b/lib/passport/strategy.js
@@ -1,5 +1,4 @@
 var
-  q = require('q'),
   LocalStrategy = require('passport-local').Strategy;
 
 module.exports = function(context) {
@@ -13,23 +12,17 @@ module.exports = function(context) {
           context.passwordManager.checkPassword(password, userObject.password || userObject._source.password)
             .then(result => {
               if (result === false) {
-                deferred.reject(new context.errors.ForbiddenError('Bad Credentials'));
+                return done(new context.errors.ForbiddenError('Bad Credentials'));
               }
-              else {
-                deferred.resolve(userObject);
-              }
+
+              done(null, userObject);
             });
         }
         else {
-          deferred.reject(new context.errors.ForbiddenError('Bad Credentials'));
+          done(new context.errors.ForbiddenError('Bad Credentials'));
         }
       })
-      .catch(function (err) {
-        deferred.reject(err);
-      });
-
-    deferred.promise.nodeify(done);
-    return deferred.promise;
+      .catch(err => done(err));
   };
 
   this.load = function(passport) {

--- a/lib/passport/strategy.js
+++ b/lib/passport/strategy.js
@@ -3,9 +3,6 @@ var
 
 module.exports = function(context) {
   this.verify = function(username, password, done) {
-    var
-      deferred = q.defer();
-
     context.accessors.users.load(username)
       .then(userObject => {
         if (userObject !== null) {

--- a/lib/passport/strategy.js
+++ b/lib/passport/strategy.js
@@ -5,10 +5,9 @@ var
 module.exports = function(context) {
   this.verify = function(username, password, done) {
     var
-      deferred = q.defer(),
-      repositories = context.accessors.repositories;
+      deferred = q.defer();
 
-    repositories.user.load(username)
+    context.accessors.users.load(username)
       .then(userObject => {
         if (userObject !== null) {
           context.passwordManager.checkPassword(password, userObject.password || userObject._source.password)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "pluginInfo": {
     "defaultConfig": {
+      "loadedBy": "server",
       "secret": "changeme",
       "algorithm": "sha1",
       "digest": "hex"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-auth-passport-local",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Kuzzle plugin to log-in users",
   "main": "./lib/index.js",
   "repository": {


### PR DESCRIPTION
Instead of the full `repositories` object been exposed in the plugin context, we now expose only a few methods that can be used by plugin developers.
This makes plugin development easier to grasp and to document.