### PR TITLE
Default config in plugin Code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 var
-  isString = require('lodash.isString'),
+  isString = require('lodash.isstring'),
   pipes = require('./config/pipes'),
   PasswordManager = require('./passwordManager'),
   Strategy = require('./passport/strategy');
@@ -12,13 +12,15 @@ function AuthPassportLocal () {
   this.context = {};
   this.pipes = pipes;
 
-  this.init = function (config, context, isDummy) {
+  this.init = function (customConfig, context, isDummy) {
     var strategy;
+    const defaultConfig = {
+      'secret': 'changeme',
+      'algorithm': 'sha1',
+      'digest': 'hex'
+    };
+    const config = Object.assign(defaultConfig, customConfig);
 
-    if (!config) {
-      console.error(new Error('plugin-auth-passport-local: A configuration is required for plugin kuzzle-plugin-auth-passport-local'));
-      return false;
-    }
     if (!config.secret) {
       console.error(new Error('plugin-auth-passport-local: The \'secret\' attribute is required'));
       return false;

--- a/package.json
+++ b/package.json
@@ -23,13 +23,6 @@
   "bugs": {
     "url": "https://github.com/kuzzleio/kuzzle-plugin-auth-passport-local/issues"
   },
-  "pluginInfo": {
-    "defaultConfig": {
-      "secret": "changeme",
-      "algorithm": "sha1",
-      "digest": "hex"
-    }
-  },
   "license": "Apache-2.0",
   "dependencies": {
     "lodash.isstring": "^4.0.1",


### PR DESCRIPTION
Adapts the plugin to the Apache-ish installation system specified in kuzzleio/kuzzle#609

The plugin has now its own default config in its own code and can run with a null customConfig passed to the init function.

**Please note** that, after merging this PR, we should update the corresponding Git submodule in Kuzzle repository.