### PR TITLE
Solve Error 500 when KuzzleUser doesn't have 'password' field'

### DIFF
--- a/lib/passport/strategy.js
+++ b/lib/passport/strategy.js
@@ -14,7 +14,7 @@ module.exports = function(context) {
             userPassword = userObject.password;
           }
           if (userPassword === null && userObject._source && userObject._source.password) {
-            userPassword = userObject._source.password
+            userPassword = userObject._source.password;
           }
 
           if (userPassword) {

--- a/lib/passport/strategy.js
+++ b/lib/passport/strategy.js
@@ -1,4 +1,4 @@
-var
+let
   LocalStrategy = require('passport-local').Strategy;
 
 module.exports = function(context) {
@@ -8,7 +8,17 @@ module.exports = function(context) {
     this.context.accessors.users.load(username)
       .then(userObject => {
         if (userObject !== null) {
-          this.context.passwordManager.checkPassword(password, userObject.password || userObject._source.password)
+          let userPassword = null;
+
+          if (userObject.password) {
+            userPassword = userObject.password;
+          }
+          if (userPassword === null && userObject._source && userObject._source.password) {
+            userPassword = userObject._source.password
+          }
+
+          if (userPassword) {
+            this.context.passwordManager.checkPassword(password, userObject.password || userObject._source.password)
             .then(result => {
               if (result === false) {
                 return done(new this.context.errors.ForbiddenError('Login failed'));
@@ -16,6 +26,10 @@ module.exports = function(context) {
 
               done(null, userObject);
             });
+          } else {
+            done(new this.context.errors.ForbiddenError('Login failed'));
+          }
+
         }
         else {
           done(new this.context.errors.ForbiddenError('Login failed'));


### PR DESCRIPTION
If you create a KuzzleUser without password, the plugin auth with local strategy crashes saying : 
```
 error: 2017-03-27T14:07:11+02:00 [LOG:ERROR] Cannot read property 'password' of undefined
 Cannot read property 'password' of undefined
 at context.accessors.users.load.then.userObject (/home/elastic/kuzzle/kuzzle/plugins/available/kuzzle-plugin-auth-passport-local/lib/passport/strategy.js:15:105)
```

This PR does :
- Checking if the password exist
- Firing login failed if the password is null