### PR TITLE
Use plugin storage to store secret configuration and change default hash configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Kuzzle compatibility
 
-Versions 3.x of this plugin are compatible with Kuzzle v1.0.0-RC.8 and upper.
+Versions 4.x of this plugin are compatible with Kuzzle v1.0.0-RC.10 and upper.
 
-For older versions of Kuzzle, install v1.x or v2.x versions of this plugin instead.
+For older versions of Kuzzle, install v1.x, v2.x or v3.x versions of this plugin instead.
 
 # Plugin Local Password Authentication
 
@@ -12,23 +12,36 @@ This plugin provides a local authentication with username/password with [passpor
 
 By default, this plugin is already installed in Kuzzle.
 
-# Manifest
-
-This plugin doesn't need any right.
-
 # Configuration
 
+The default configuration is:
+
+```json
+{
+  "secret": null,
+  "algorithm": "sha256",
+  "digest": "hex"
+}
+```
+
+All the configurations are used to set the behavior of the password hash.
+If `secret` is `null`, it will be generated automatically when the plugin is initalized for the first time.
+To change this configuration please refer to the [Plugin reference](http://docs.kuzzle.io/plugin-reference/#custom-plugin-configuration).
+
+Note: If this configuration is changed when users already exist, they won't be able to authenticate anymore.
 
 # Usage
 
 Just send following data to the **auth** controller:
 
 ```json
-{"body":{
-  "strategy": "local",
-  "username": "<username>",
-  "password":"<password>"
-}}
+{
+  "body": {
+    "strategy": "local",
+    "username": "<username>",
+    "password": "<password>"
+  }
+}
 ```
 
 See [Kuzzle API Documentation](http://kuzzleio.github.io/kuzzle-api-documentation/#auth-controller) for more details about Kuzzle authentication mechanism.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 [![Build Status](https://travis-ci.org/kuzzleio/kuzzle-plugin-auth-passport-local.svg?branch=master)](https://travis-ci.org/kuzzleio/kuzzle-plugin-auth-passport-local)
 
-# Kuzzle compatibility
-
-Versions 4.x of this plugin are compatible with Kuzzle v1.0.0-RC.10 and upper.
-
-For older versions of Kuzzle, install v1.x, v2.x or v3.x versions of this plugin instead.
-
 # Plugin Local Password Authentication
 
 This plugin provides a local authentication with username/password with [passportjs module](http://passportjs.org/docs/username-password).
@@ -28,7 +22,7 @@ All the configurations are used to set the behavior of the password hash.
 If `secret` is `null`, it will be generated automatically when the plugin is initalized for the first time.
 To change this configuration please refer to the [Plugin reference](http://docs.kuzzle.io/plugin-reference/#custom-plugin-configuration).
 
-Note: If this configuration is changed when users already exist, they won't be able to authenticate anymore.
+Note: thesecretparameter is only used if there is no salt already configured in the database. If that's the case and if users are already stored, make sure that it matches the previously used salt
 
 # Usage
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,51 +1,94 @@
-var
+const
   isString = require('lodash.isstring'),
+  crypto = require('crypto'),
   pipes = require('./config/pipes'),
   PasswordManager = require('./passwordManager'),
-  Strategy = require('./passport/strategy');
+  Strategy = require('./passport/strategy'),
+  defaultConfig = {
+    'secret': null,
+    'algorithm': 'sha256',
+    'digest': 'hex'
+  },
+  storageMapping = {
+    configuration: {
+      properties: {
+        configurationValue: {
+          type: 'keyword'
+        }
+      }
+    }
+  };
 
 /**
- * @constructor
+ * @class AuthPassportLocal
+ * @property {?KuzzlePluginContext} context
+ * @property {object} pipes
+ * @property {object} configurationRepository
+ * @property {object} passwordRepository
+ * @property {object} anonymousUser
+ * @property {object} routes
+ * @property {object} controllers
  */
-function AuthPassportLocal () {
-  this.isDummy = true;
-  this.context = {};
-  this.pipes = pipes;
+class AuthPassportLocal {
+  /**
+   * @constructor
+   */
+  constructor () {
+    this.context = null;
+    this.pipes = pipes;
+    this.configRepository = null;
+    this.passwordRepository = null;
+  }
 
-  this.init = function (customConfig, context, isDummy) {
-    var strategy;
-    const defaultConfig = {
-      'secret': 'changeme',
-      'algorithm': 'sha1',
-      'digest': 'hex'
-    };
-    const config = Object.assign(defaultConfig, customConfig);
+  /**
+   * @param {object} customConfig
+   * @param {KuzzlePluginContext} context
+   * @returns {*}
+   */
+  init (customConfig, context) {
+    let strategy;
+    this.config = Object.assign(defaultConfig, customConfig);
 
-    if (!config.secret) {
-      console.error(new Error('plugin-auth-passport-local: The \'secret\' attribute is required'));
-      return false;
-    }
-    if (!config.algorithm) {
+    if (!this.config.algorithm) {
       console.error(new Error('plugin-auth-passport-local: The \'algorithm\' attribute is required'));
       return false;
     }
-    if (!config.digest) {
+    if (!this.config.digest) {
       console.error(new Error('plugin-auth-passport-local: The \'digest\' attribute is required'));
       return false;
     }
 
-    this.isDummy = isDummy;
     this.context = context;
+    this.configRepository = new this.context.constructors.Repository('configuration');
 
-    this.context.passwordManager = new PasswordManager(config);
+    return this.context.accessors.storage.bootstrap(storageMapping)
+      .then(() => this.configRepository.get('secret'))
+      .then(result => {
+        if (result && result.configurationValue) {
+          this.config.secret = result.configurationValue;
+          return Promise.resolve();
+        }
 
-    strategy = new Strategy(this.context);
-    strategy.load();
+        if (!this.config.secret) {
+          this.config.secret = crypto.randomBytes(64).toString('hex');
+        }
 
-    return this;
-  };
+        return this.configRepository.create({_id: 'secret', configurationValue: this.config.secret});
+      })
+      .then(() => {
+        strategy = new Strategy(this.context);
+        strategy.load();
 
-  this.cleanUserCredentials = function(user, callback) {
+        this.context.passwordManager = new PasswordManager(this.config);
+
+        return true;
+      });
+  }
+  /**
+   * @param {object<string, *>} user
+   * @param {function} callback
+   */
+  cleanUserCredentials (user, callback) {
     try {
       if (user._source !== undefined) {
         delete user._source.password;
@@ -56,9 +99,13 @@ function AuthPassportLocal () {
     catch (error) {
       callback(error);
     }
-  };
+  }
 
-  this.encryptCredentials = function(request, callback) {
+  /**
+   * @param {KuzzleRequest} request
+   * @param {function} callback
+   */
+  encryptCredentials (request, callback) {
     if (request.input.body.password === undefined) {
       // The plugin does not enforce the password in case another plugin is installed
       // @todo: add some configuration check on whether to trigger an error
@@ -75,7 +122,7 @@ function AuthPassportLocal () {
 
     this.context.passwordManager.encryptPassword(request.input.body.password)
       .then(encryptedPassword => {
-        var pjson = require('../package.json');
+        const pjson = require('../package.json');
 
         request.input.body.password = encryptedPassword;
 
@@ -95,7 +142,7 @@ function AuthPassportLocal () {
         callback(null, request);
       })
       .catch(error => callback(error));
-  };
+  }
 }
 
 module.exports = AuthPassportLocal;

--- a/lib/passport/strategy.js
+++ b/lib/passport/strategy.js
@@ -1,10 +1,24 @@
-var
-  LocalStrategy = require('passport-local').Strategy;
+const LocalStrategy = require('passport-local').Strategy;
 
-module.exports = function(context) {
-  this.context = context;
+/**
+ * @class Strategy
+ * @property {object} context
+ */
+class Strategy {
+  /**
+   * @param {object} context
+   * @constructor
+   */
+  constructor (context) {
+    this.context = context;
+  }
 
-  this.verify = function(username, password, done) {
+  /**
+   * @param {string} username
+   * @param {string} password
+   * @param {function} done
+   */
+  verify (username, password, done) {
     this.context.accessors.users.load(username)
       .then(userObject => {
         if (userObject !== null) {
@@ -22,9 +36,11 @@ module.exports = function(context) {
         }
       })
       .catch(err => done(err));
-  };
+  }
 
-  this.load = function() {
+  load () {
     this.context.accessors.passport.use(new LocalStrategy(this.verify.bind(this)));
-  };
-};
+  }
+}
+
+module.exports = Strategy;

--- a/lib/passwordManager.js
+++ b/lib/passwordManager.js
@@ -1,22 +1,41 @@
-var
-  crypto = require('crypto');
+const crypto = require('crypto');
 
 /**
- * @param {object} config
- * @constructor
+ * @class PasswordManager
  */
-function PasswordManager (config) {
-  this.encryptPassword = function (password) {
-    var hashedPassword = crypto.createHmac(config.algorithm, config.secret).update(password).digest(config.digest);
-    return Promise.resolve(hashedPassword);
-  };
+class PasswordManager {
+  /**
+   * @param {object} config
+   * @constructor
+   */
+  constructor (config) {
+    this.config = config;
+  }
 
-  this.checkPassword = function (password, hash) {
+  /**
+   * @param {string} password
+   * @returns {Promise.<string>}
+   */
+  encryptPassword (password) {
+    const hashedPassword = crypto
+      .createHmac(this.config.algorithm, this.config.secret)
+      .update(password)
+      .digest(this.config.digest);
+
+    return Promise.resolve(hashedPassword);
+  }
+
+  /**
+   * @param {string} password
+   * @param {string} hash
+   * @returns {Promise.<string>}
+   */
+  checkPassword (password, hash) {
     return this.encryptPassword(password)
       .then(function (value) {
         return Promise.resolve(hash === value);
       });
-  };
+  }
 }
 
 module.exports = PasswordManager;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-auth-passport-local",
-  "version": "3.0.4",
+  "version": "4.0.0",
   "description": "Kuzzle plugin to log-in users",
   "main": "./lib/index.js",
   "repository": {


### PR DESCRIPTION
**Breaking changes:**

* Change default value of configuration `secret` and `algorithm`; Can lead to login failure if plugin is updated on an existing install.
* Generate the `secret` configuration if it is `null` (default value); Can still be defined using RC and env mechanisms.

**Enhancements:**

* Store the `secret` configuration in the plugin storage. Once initialized in the plugin storage, the secret will be taken from it instead of configuration files (or env).

fixes: #32 #29

partially fixes (hash)22 (stores configuration but not passwords in plugin storage)