### PR TITLE
fix README sample body

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ Just send following data to the **auth** controller:
 
 ```json
 {
+  "controller": "auth",
+  "action": "login",
+  "strategy": "local",
   "body": {
-    "strategy": "local",
     "username": "<username>",
     "password": "<password>"
   }


### PR DESCRIPTION
following https://github.com/kuzzleio/kuzzle/pull/840, `strategy` attribute is moved from the `input.body` to `input.args`
