### PR TITLE
Remove strategy constructors support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 const
   crypto = require('crypto'),
-  semver = require('semver'),
   PasswordManager = require('./passwordManager'),
   LocalStrategy = require('passport-local').Strategy,
   defaultConfig = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,8 +51,7 @@ class AuthenticationPlugin {
     this.strategy = null;
     this.userRepository = null;
     this.passwordManager = null;
-    // to be used with Kuzzle post-1.4.0
-    this.authenticators = {LocalStrategy};
+    this.authenticators = { LocalStrategy };
   }
 
   /**
@@ -99,6 +98,7 @@ class AuthenticationPlugin {
     this.strategies = {
       local: {
         config: {
+          authenticator: 'LocalStrategy',
           strategyOptions: {},
           authenticateOptions: {
             scope: []
@@ -117,15 +117,6 @@ class AuthenticationPlugin {
         }
       }
     };
-
-    // This snippet simply suppresses a warning emitted by Kuzzle during
-    // plugin initialization.
-    // See https://github.com/kuzzleio/kuzzle/pull/1145
-    if (semver.lt(this.context.config.version, '1.4.0')) {
-      this.strategies.local.config.constructor = LocalStrategy;
-    } else {
-      this.strategies.local.config.authenticator = 'LocalStrategy';
-    }
   }
 
   /**


### PR DESCRIPTION
## What does this PR do?

Strategy constructors are deprecated since Kuzzle 1.4.0.  
They are removed in Kuzzle v2
