### PR TITLE
requirePassword should only apply to the auth controller

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -387,7 +387,7 @@ class AuthenticationPlugin {
    */
   async passwordRequiredCheck (request, user) {
     if ( !this.config.requirePassword
-      || request.input.controller === 'security'
+      || request.input.controller !== 'auth'
     ) {
       return;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-auth-passport-local",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-auth-passport-local",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Kuzzle plugin to log-in users",
   "main": "./lib/index.js",
   "repository": {

--- a/test/delete.test.js
+++ b/test/delete.test.js
@@ -34,7 +34,7 @@ describe('#delete', () => {
       pluginLocal.userRepository.search = () => Promise.resolve({total: 1, hits: [{_id: 'foo', kuid: 'someId'}]});
       pluginLocal.config.requirePassword = true;
       pluginLocal.passwordManager = {checkPassword: sinon.stub().returns(true)};
-      request = {input: {args: {}}};
+      request = {input: {args: {}, controller: 'auth'}};
     });
 
     it('should reject if no password is provided', () => {
@@ -48,9 +48,9 @@ describe('#delete', () => {
         .rejectedWith('Cannot update credentials: password required.');
     });
 
-    it('should accept if no password is provided but the request is from the security controller', () => {
+    it('should accept if no password is provided but the request is not from the auth controller', () => {
       request.input.args.password = '';
-      request.input.controller = 'security';
+      request.input.controller = null;
       return should(pluginLocal.delete(request, {username: 'foo', 'password': 'bar'}))
         .fulfilled();
     });

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -47,7 +47,7 @@ describe('#update', () => {
       pluginLocal.userRepository.update = () => Promise.resolve({_id: 'foo', kuid: 'someId'});
       pluginLocal.config.requirePassword = true;
       pluginLocal.passwordManager.checkPassword = sinon.stub().returns(true);
-      request = {input: {args: {}}};
+      request = {input: {args: {}, controller: 'auth'}};
     });
 
     it('should reject if no password is provided', () => {
@@ -61,9 +61,9 @@ describe('#update', () => {
         .rejectedWith('Cannot update credentials: password required.');
     });
 
-    it('should accept if no password is provided but the request is from the security controller', () => {
+    it('should accept if no password is provided but the request is not from the auth controller', () => {
       request.input.args.password = '';
-      request.input.controller = 'security';
+      request.input.controller = null;
       return should(pluginLocal.update(request, {username: 'foo', 'password': 'bar'}))
         .fulfilled();
     });


### PR DESCRIPTION
# Description

The `requirePassword` configuration introduced in 6.1.0 asks for the old password when updating or deleting a user's credentials, but only `if the requesting controller is not "security"`. Otherwise, admins couldn't update users, set passwords, etc.

Problem is: there are other Kuzzle API routes asking for credential deletions, mainly because the user itself is being deleted, and those calls should not be blocked.

So the logic has been slightly changed, and the protection now only affects API calls resulting from the `auth` controller, meaning that calls from the security controller, the admin one, or even from internal Kuzzle tasks are not blocked anymore.

# Why a hotfix?

Because `admin:loadSecurities` first deletes existing users before loading the security fixtures, and because of this bug, user credentials are not deleted. 
Kuzzle detects this and refuses to create a user if there are credentials existing on it: it handles that as a db inconsistency and bails out, which is intended and a good thing.

When Kuzzle is started with the --securities flag, because the admin:loadSecurities route fails, Kuzzle refuses to complete its start sequence and stops.