### PR TITLE
Use a whitelist instead of a blacklist for search action

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,6 +126,37 @@ class AuthenticationPlugin {
     this._CONFIG_RESET_TOKEN_SECRET_ID = 'resetTokenSecret';
 
     this.User = getUserConstructor(this);
+
+    this.queryWhitelist = [
+      // Boolean queries
+      'bool',
+      'filter',
+      'must',
+      'must_not',
+      'should',
+      // Match queries
+      'fuziness',
+      'match',
+      'query',
+      // Prefix Queries
+      'prefix',
+      'value', // also in term queries
+      // Term Queries
+      'boost',
+      'term',
+      'terms',
+      // Searchable field
+      'username'
+    ];
+
+    this.sortWhitelist = [
+      // Sorting
+      'sort',
+      'order',
+      // Sortable fields
+      'kuid',
+      'username'
+    ];
   }
 
   get configRepository() {
@@ -493,8 +524,8 @@ class AuthenticationPlugin {
   async search (searchBody, { from, size } = {}) {
     debug('exists(searchBody = %j)', searchBody);
 
-    let sort;
     let query;
+    let sort;
     let keywordWhitelist;
 
     const sanitizeSearchBody = key => {
@@ -512,39 +543,12 @@ class AuthenticationPlugin {
     };
 
     if (isPlainObject(searchBody.query)) {
-      keywordWhitelist = [
-        // Boolean queries
-        'bool',
-        'filter',
-        'must',
-        'must_not',
-        'should',
-        // Match queries
-        'fuziness',
-        'match',
-        'query',
-        // Prefix Queries
-        'prefix',
-        'value', // also in term queries
-        // Term Queries
-        'boost',
-        'term',
-        'terms',
-        // Searchable field
-        'username'
-      ];
+      keywordWhitelist = this.queryWhitelist;
       query = objectRecursiveMap(searchBody.query, sanitizeSearchBody);
     }
 
     if (isPlainObject(searchBody.sort) || Array.isArray(searchBody.sort)) {
-      keywordWhitelist = [
-        // Sorting
-        'sort',
-        'order',
-        // Sortable fields
-        'kuid',
-        'username'
-      ];
+      keywordWhitelist = this.sortWhitelist;
       ({ sort } = objectRecursiveMap({ sort: searchBody.sort }, sanitizeSearchBody));
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -497,7 +497,7 @@ class AuthenticationPlugin {
     let query;
     let keywordWhitelist;
 
-    const sanitizeSearchBody = (key) => {
+    const sanitizeSearchBody = key => {
       if (key === 'username') {
         return { key: '_id' };
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -529,6 +529,7 @@ class AuthenticationPlugin {
         // Term Queries
         'boost',
         'term',
+        'terms',
         // Searchable field
         'username'
       ];
@@ -538,6 +539,7 @@ class AuthenticationPlugin {
     if (isPlainObject(searchBody.sort) || Array.isArray(searchBody.sort)) {
       keywordWhitelist = [
         // Sorting
+        'sort',
         'order',
         // Sortable fields
         'kuid',

--- a/lib/index.js
+++ b/lib/index.js
@@ -495,49 +495,55 @@ class AuthenticationPlugin {
 
     let sort;
     let query;
-    let isRequiredFieldsInBody = false;
-    const forbiddenFields = extractESMappingFields(storageMapping.users);
-    const forbiddenKeywords = [
-      'multi_match',
-    ]; // @todo Keep up to date this blacklist to prevent queries on forbiddenFields
+    let keywordWhitelist;
 
-    const sanitizeSearchBody = (key, value) => {
+    const sanitizeSearchBody = (key) => {
       if (key === 'username') {
-        isRequiredFieldsInBody = true;
         return { key: '_id' };
       }
-      else if (value === 'username') {
-        isRequiredFieldsInBody = true;
-        return { value: '_id' };
-      }
-      else if (forbiddenKeywords.includes(key)) {
+      else if (! keywordWhitelist.includes(key)) {
+        const forbiddenFields = extractESMappingFields(storageMapping.users);
+        if (forbiddenFields.includes(key)) {
+          throw new ForbiddenError(`Forbidden field "${key}". Only the "username" or "kuid" fields are sortable and only the first is also searchable.`);
+        }
         throw new BadRequestError(`The "${key}" keyword is not allowed in this search query for security concerns.`);
-      }
-      else if (forbiddenFields.some(property => property === key || property === value)) {
-        throw new ForbiddenError(`Forbidden field "${key}". Only the "username" or "kuid" fields are sortable and only the first is also searchable.`);
       }
       return {};
     };
 
     if (isPlainObject(searchBody.query)) {
+      keywordWhitelist = [
+        // Boolean queries
+        'bool',
+        'filter',
+        'must',
+        'must_not',
+        'should',
+        // Match queries
+        'fuziness',
+        'match',
+        'query',
+        // Prefix Queries
+        'prefix',
+        'value', // also in term queries
+        // Term Queries
+        'boost',
+        'term',
+        // Searchable field
+        'username'
+      ];
       query = objectRecursiveMap(searchBody.query, sanitizeSearchBody);
-      if (! isRequiredFieldsInBody) {
-        throw new BadRequestError('Only the "username" field is searchable, otherwise leave the query empty.');
-      }
-      isRequiredFieldsInBody = false;
     }
 
-    if (typeof searchBody.sort === 'object') {
-      ({ sort } = objectRecursiveMap({ sort: searchBody.sort }, (key, value) => {
-        if (key === 'kuid' || value === 'kuid') {
-          isRequiredFieldsInBody = true;
-          return {};
-        }
-        return sanitizeSearchBody(key, value);
-      }));
-      if (! isRequiredFieldsInBody) {
-        throw new BadRequestError('Only the "username" or "kuid" fields are sortable.');
-      }
+    if (isPlainObject(searchBody.sort) || Array.isArray(searchBody.sort)) {
+      keywordWhitelist = [
+        // Sorting
+        'order',
+        // Sortable fields
+        'kuid',
+        'username'
+      ];
+      ({ sort } = objectRecursiveMap({ sort: searchBody.sort }, sanitizeSearchBody));
     }
 
     const result = await this.getUsersRepository().search(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,16 +22,16 @@
 'use strict';
 
 /**
- * 
+ *
  * @param {any} object Object to test
  * @returns {boolean} true if it's a plain object, false otherwise
  */
 function isPlainObject (object) {
-  return object !== null && typeof object === 'object' && !Array.isArray(object);
+  return Object.prototype.toString.call(object) === '[object Object]';
 }
 
 /**
- * 
+ *
  * @param {Object} object Plain object to map
  * @param {(key: string, value: any, index: number) => {key: string, value: any}} fn Map function returning an object containing what must be updated (key/value)
  * @returns {Object} Mapped object
@@ -43,10 +43,10 @@ const objectRecursiveMap = (object, fn) => {
         let { key: newKey = key, value: newValue = value } = fn(key, value, index);
 
         if (Array.isArray(newValue)) {
-          newValue = newValue.map(item => 
-            typeof item === 'object' ? objectRecursiveMap(item, fn) : item);
+          newValue = newValue.map(item =>
+            isPlainObject(item) ? objectRecursiveMap(item, fn) : item);
         }
-        else if (typeof newValue === 'object' && newValue !== null) {
+        else if (isPlainObject(newValue)) {
           newValue = objectRecursiveMap(newValue, fn);
         }
 
@@ -59,10 +59,10 @@ const objectRecursiveMap = (object, fn) => {
 /**
  * Extract fields and their nested field from an ES mapping object in a flat array
  * Example: { field : { 1: "nested", 2: "nested" } } => [ 'field', 'field.1', 'field.2' ]
- * 
+ *
  * @param {Object} mappings ES mappings
  * @param {Array<string>} fieldsToIgnore Fields (and their nested fields) which must not be considered
- * @returns {Array<string>} 
+ * @returns {Array<string>}
  */
 function extractESMappingFields(mappings, fieldsToIgnore = [], path = '') {
   let fields = [];


### PR DESCRIPTION
## What does this PR do?

Search by credentials is a useful feature but its security is a real headache... In order to guarantee a maximum security we need to restrain its usages.

In this PR, the previous blacklist about ES keywords is replaced by a safer whitelist which shouldn't be too restrictive even though it eliminates some possibilities. Bool, match, prefix & term queries are still available with some limited options. If you need a specific ES keyword that is not available, feel free to make a PR, if it's considered safe enough by the team, it should be merged.

### How should this be manually tested?

Start a Kuzzle and use the action `security:searchUsersByCredentials` with local strategy.
Try several query some will be accepted while other will be rejected for security reasons.
Note: Changes are mostly behind the scene.
