### PR TITLE
Add kuzzle in peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-auth-passport-local",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-auth-passport-local",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "Kuzzle plugin to log-in users",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "should-sinon": "0.0.6",
     "sinon": "^11.1.1"
   },
+  "peerDependencies": {
+    "kuzzle": "^2.12.2"
+  },
   "homepage": "https://github.com/kuzzleio/kuzzle-plugin-auth-passport-local#readme",
   "maintainers": [
     {


### PR DESCRIPTION
## What does this PR do?

The `kuzzle` package was not present in the `peerDependencies`, causing errors when trying to require this package inside the plugin.