### PR TITLE
Apply refresh parameter propagation to all writing operations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -380,7 +380,7 @@ class AuthenticationPlugin {
    * @returns {Promise<object>}
    */
   async create (request, credentials, kuid) {
-    const refresh = request.getString('refresh', 'wait_for');
+    const refresh = request.getRefresh('wait_for');
 
     if (!credentials.password) {
       throw new this.context.errors.BadRequestError('Password needed.');
@@ -420,7 +420,7 @@ class AuthenticationPlugin {
    * @returns {Promise<object>}
    */
   async update (request, credentials, kuid) {
-    const refresh = request.getString('refresh', 'wait_for');
+    const refresh = request.getRefresh('wait_for');
 
     if (credentials.kuid) {
       throw new this.context.errors.BadRequestError('The request must not contain a kuid attribute.');
@@ -501,7 +501,7 @@ class AuthenticationPlugin {
    * @returns {Promise<object>}
    */
   async delete (request, kuid) {
-    const refresh = request.getString('refresh', 'wait_for');
+    const refresh = request.getRefresh('wait_for');
 
     const user = await this.getCredentialsFromUserId(kuid);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -480,7 +480,7 @@ class AuthenticationPlugin {
       newDocument._id = credentials.username;
       delete newDocument.username;
 
-      updated = await this.getUsersRepository().create(newDocument);
+      updated = await this.getUsersRepository().create(newDocument, { refresh });
       // wait for refresh only after the 2nd action
       await this.getUsersRepository().delete(oldDocumentId, { refresh });
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -481,7 +481,6 @@ class AuthenticationPlugin {
       delete newDocument.username;
 
       updated = await this.getUsersRepository().create(newDocument, { refresh });
-      // wait for refresh only after the 2nd action
       await this.getUsersRepository().delete(oldDocumentId, { refresh });
     }
     else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-auth-passport-local",
-  "version": "6.3.5",
+  "version": "6.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3897,15 +3897,6 @@
             "pause": "0.0.1"
           }
         }
-      }
-    },
-    "kuzzle-common-objects": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/kuzzle-common-objects/-/kuzzle-common-objects-5.0.2.tgz",
-      "integrity": "sha512-3XNx1Imgba0UHrtrMCCNc2stsEojyCKEEvhXIhAFOcLDx8vxZb7SUw+43sNtd44CJ+hXqJd7izBfl1hfysUr2A==",
-      "dev": true,
-      "requires": {
-        "uuid": "^8.3.1"
       }
     },
     "kuzzle-plugin-auth-passport-local": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-auth-passport-local",
-  "version": "6.3.5",
+  "version": "6.3.6",
   "description": "Kuzzle plugin to log-in users",
   "main": "./lib/index.js",
   "repository": {


### PR DESCRIPTION
## What does this PR do?
Add a missing propagated refresh parameter to a user creation to fix this kind of inconsistent database (https://github.com/kuzzleio/kuzzle/runs/4934352096?check_suite_focus=true#step:6:439)

### Boyscout

Use KuzzleRequest.getRefresh instead of KuzzleRequest.getString to retrieve the refresh parameter
